### PR TITLE
Bump rubocop to support ruby 2.6 development

### DIFF
--- a/anycable-rack-server.gemspec
+++ b/anycable-rack-server.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.10'
   s.add_development_dependency 'puma'
   s.add_development_dependency 'rake', '~> 12.3'
-  s.add_development_dependency 'rubocop', "~> 0.60.0"
+  s.add_development_dependency 'rubocop', "~> 0.61.0"
 end


### PR DESCRIPTION
Rubocop failed when using Ruby 2.6 in development

```
unknown keywords: whitelist_classes, whitelist_symbols
/home/manuelpuyol/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/psych.rb:328:in `safe_load'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:185:in `yaml_safe_load'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:159:in `load_yaml_configuration'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:40:in `load_file'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/lib/rubocop/config_loader.rb:82:in `configuration_from_file'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/lib/rubocop/config_store.rb:44:in `for'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/lib/rubocop/cli.rb:187:in `apply_default_formatter'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/lib/rubocop/cli.rb:40:in `run'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/exe/rubocop:13:in `block in <top (required)>'
/home/manuelpuyol/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/benchmark.rb:308:in `realtime'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/gems/rubocop-0.60.0/exe/rubocop:12:in `<top (required)>'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/bin/rubocop:23:in `load'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/bin/rubocop:23:in `<main>'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/bin/ruby_executable_hooks:24:in `eval'
/home/manuelpuyol/.rvm/gems/ruby-2.6.0@qultureapp/bin/ruby_executable_hooks:24:in `<main>'
```

CI is also breaking due to this error:
https://travis-ci.org/anycable/anycable-rack-server/jobs/481040945?utm_medium=notification&utm_source=github_status

Bumping rubocop to 0.61 fixes this issue, supporting Ruby 2.6 :)