### PR TITLE
Bump copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2022 Yulia Oletskaya, Vladimir Dementyev
+Copyright (c) 2019-2026 Yulia Oletskaya, Vladimir Dementyev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Refresh the copyright end-year to 2026 (repo is still actively maintained).